### PR TITLE
Fixed build for linux 5.17

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1207,7 +1207,11 @@ u32 _rtw_down_sema(_sema *sema)
 inline void thread_exit(_completion *comp)
 {
 #ifdef PLATFORM_LINUX
-	complete_and_exit(comp, 0);
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+		complete_and_exit(comp, 0);
+	#else
+		kthread_complete_and_exit(comp, 0);
+	#endif
 #endif
 
 #ifdef PLATFORM_FREEBSD


### PR DESCRIPTION
Fixes the build on linux 5.17 based systems

Linux 5.17 renames `complete_and_exit` to `kthread_complete_and_exit`