### PR TITLE
add ability to override TX power index dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ $ sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makef
   ```
   $ ip link set <wlan1> up
   ```
-For setting TX power
+For setting TX power to a fixed index (1=min, 63=max)
 ```
-$ iwconfig <wlan1> txpower 30
+$ iwconfig <wlan1> txpower -30
 or
-$ iw <wlan1> set txpower fixed 3000
+$ iw <wlan1> set txpower fixed -3000
 ```
 ### LED control
 

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -1362,8 +1362,7 @@ phy_SetTxPowerByRateBase(
 		return;
 	}
 
-	if (Adapter->registrypriv.RegTxPowerIndexOverride)
-		Value = Adapter->registrypriv.RegTxPowerIndexOverride;
+	Value = get_overridden_tx_power_index(Value);
 
 	if (DBG_TX_POWER_IDX)
 		RTW_INFO( "TXPWR: by-rate-base [%sG][%c] RateSection:%d = %d\n",
@@ -2668,7 +2667,7 @@ PHY_SetTxPowerByRate(
 
 	/* Disable offset when override is enabled jic, even
 		though its value should not be used in that case anyway. */
-	if (pAdapter->registrypriv.RegTxPowerIndexOverride) Value = 0;
+	if (get_overridden_tx_power_index(0)) Value = 0;
 
 	if (DBG_TX_POWER_IDX)
 		RTW_INFO( "TXPWR: by-rate-offset [%sG][%c] Rate:%s = %d\n",
@@ -2729,8 +2728,7 @@ PHY_SetTxPowerIndexByRateArray(
 
 	for (i = 0; i < RateArraySize; ++i) {
 
-		if (pAdapter->registrypriv.RegTxPowerIndexOverride)
-			powerIndex = (u32)pAdapter->registrypriv.RegTxPowerIndexOverride;
+		powerIndex = (u32)get_overridden_tx_power_index((u8)powerIndex);
 
 #if DBG_TX_POWER_IDX
 		//struct txpwr_idx_comp tic;
@@ -3520,9 +3518,7 @@ PHY_SetTxPowerIndex(
 	IN	u8				Rate
 )
 {
-
-	if (pAdapter->registrypriv.RegTxPowerIndexOverride)
-		PowerIndex = (u32)pAdapter->registrypriv.RegTxPowerIndexOverride;
+	PowerIndex = (u32)get_overridden_tx_power_index((u8)PowerIndex);
 
 	if (DBG_TX_POWER_IDX)
 		RTW_INFO( "TXPWR: set-index [%c] %s = %d\n",

--- a/hal/rtl8812a/rtl8812a_phycfg.c
+++ b/hal/rtl8812a/rtl8812a_phycfg.c
@@ -587,8 +587,7 @@ PHY_GetTxPowerIndex_8812A(
 	by_rate_diff = by_rate_diff > limit ? limit : by_rate_diff;
 	power_idx = base_idx + by_rate_diff + tpt_offset + extra_bias;
 
-	if (pAdapter->registrypriv.RegTxPowerIndexOverride)
-		power_idx = pAdapter->registrypriv.RegTxPowerIndexOverride;
+	power_idx = get_overridden_tx_power_index(power_idx);
 
 	if (power_idx > MAX_POWER_INDEX)
 		power_idx = MAX_POWER_INDEX;
@@ -616,8 +615,7 @@ PHY_SetTxPowerIndex_8812A(
 {
 	HAL_DATA_TYPE		*pHalData	= GET_HAL_DATA(Adapter);
 
-	if (Adapter->registrypriv.RegTxPowerIndexOverride)
-		PowerIndex = (u32)Adapter->registrypriv.RegTxPowerIndexOverride;
+	PowerIndex = (u32)get_overridden_tx_power_index((u8)PowerIndex);
 
 	/* <20120928, Kordan> A workaround in 8812A/8821A testchip, to fix the bug of odd Tx power indexes. */
 	if ((PowerIndex % 2 == 1) && IS_HARDWARE_TYPE_JAGUAR(Adapter) && IS_TEST_CHIP(pHalData->version_id))

--- a/include/drv_types.h
+++ b/include/drv_types.h
@@ -333,7 +333,6 @@ struct registry_priv {
 	u8	RegEnableTxPowerLimit;
 #endif
 	u8	RegEnableTxPowerByRate;
-	u8	RegTxPowerIndexOverride;
 
 	u8 target_tx_pwr_valid;
 	s8 target_tx_pwr_2g[RF_PATH_MAX][RATE_SECTION_NUM];
@@ -441,6 +440,20 @@ struct registry_priv {
   u8 led_enable;
 #endif
 };
+
+extern int rtw_tx_pwr_idx_override;
+static u8 get_overridden_tx_power_index(u8 index) {
+	int override_index = *(volatile int*)&rtw_tx_pwr_idx_override;
+	if (override_index < 0)
+		override_index = 0;
+	if (override_index > MAX_POWER_INDEX)
+		override_index = MAX_POWER_INDEX;
+	*(volatile int*)&rtw_tx_pwr_idx_override = override_index;
+
+	if (override_index)
+		return (u8)override_index;
+	return index;
+}
 
 /* For registry parameters */
 #define RGTRY_OFT(field) ((ULONG)FIELD_OFFSET(struct registry_priv, field))

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1000,10 +1000,6 @@ uint loadparam(_adapter *padapter)
 #endif
 	registry_par->RegEnableTxPowerByRate = (u8)rtw_tx_pwr_by_rate;
 
-	if (rtw_tx_pwr_idx_override > MAX_POWER_INDEX)
-		rtw_tx_pwr_idx_override = MAX_POWER_INDEX;
-	registry_par->RegTxPowerIndexOverride = (u8)rtw_tx_pwr_idx_override;
-
 	rtw_regsty_load_target_tx_power(registry_par);
 
 	registry_par->TxBBSwing_2G = (s8)rtw_TxBBSwing_2G;


### PR DESCRIPTION
Index N (1-63) can be set using a fixed power to `iw` of -N*100.

e.g. index 45: `iw dev <interface> set txpower fixed -4500`

The current override index, if any, is displayed as a negative number by `iw dev <interface> info`. To disable the override, use a non-negative power value.

The TX power index override can still be set on load by using the module parameter `rtw_tx_pwr_idx_override`, but changing it through sysfs is (still) ineffective.

Tested on AWUS036ACH with a spectrum analyzer connected to the output.