### PR TITLE
Compile fix for kernel 6.15 up to kernel 6.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1536,6 +1536,12 @@ ifneq ($(USER_MODULE_NAME),)
 MODULE_NAME := $(USER_MODULE_NAME)_wfb
 endif
 
+EXTRA_CFLAGS += -Wno-missing-prototypes -Wno-header-guard -Wno-missing-declarations
+asflags-y += $(EXTRA_AFLAGS)
+ccflags-y += $(EXTRA_CFLAGS)
+cppflags-y += $(EXTRA_CPPFLAGS)
+ldflags-y += $(EXTRA_LDFLAGS)
+
 ifneq ($(KERNELRELEASE),)
 
 rtk_core :=	core/rtw_cmd.o \

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -369,13 +369,15 @@ __inline static unsigned char _cancel_timer_ex(_timer *ptimer)
 {
 	u8 bcancelled;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+	return timer_delete_sync(&ptimer->t);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
 	return del_timer_sync(&ptimer->t);
 #else
 	_cancel_timer(ptimer, &bcancelled);
 
 	return bcancelled;
-#endif //(LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+#endif
 }
 
 static __inline void thread_enter(char *name)

--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -304,13 +304,19 @@ __inline static void rtw_list_delete(_list *plist)
 	list_del_init(plist);
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0))
+static void legacy_timer_emu_func(struct timer_list *t)
+{
+  struct legacy_timer_emu *lt = timer_container_of(lt, t, t);
+  lt->function(lt->data);
+}
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
 static void legacy_timer_emu_func(struct timer_list *t)
 {
   struct legacy_timer_emu *lt = from_timer(lt, t, t);
   lt->function(lt->data);
 }
-#endif //(LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+#endif
 
 __inline static void _init_timer(_timer *ptimer, _nic_hdl nic_hdl, void *pfunc, void *cntx)
 {
@@ -335,11 +341,13 @@ __inline static void _set_timer(_timer *ptimer, u32 delay_time)
 
 __inline static void _cancel_timer(_timer *ptimer, u8 *bcancelled)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0))
+  *bcancelled = timer_delete_sync(&ptimer->t) == 1 ? 1 : 0;
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
 	*bcancelled = del_timer_sync(&ptimer->t) == 1 ? 1 : 0;
 #else
 	*bcancelled = del_timer_sync(ptimer) == 1 ? 1 : 0;
-#endif //(LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+#endif
 }
 
 static inline void _init_workitem(_workitem *pwork, void *pfunc, void *cntx)

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2855,7 +2855,11 @@ exit:
 
 }
 
-static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+static int cfg80211_rtw_set_wiphy_params(struct wiphy *wiphy,
+#if (CFG80211_API_LEVEL >= KERNEL_VERSION(6, 17, 0))
+  int radio_idx,
+#endif
+  u32 changed)
 {
 #if 0
 	struct iwm_priv *iwm = wiphy_to_iwm(wiphy);
@@ -3661,6 +3665,9 @@ static int cfg80211_rtw_set_txpower(struct wiphy *wiphy,
 #if (CFG80211_API_LEVEL >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
 #endif
+#if (CFG80211_API_LEVEL >= KERNEL_VERSION(6, 17, 0))
+  int radio_idx,
+#endif
 #if (CFG80211_API_LEVEL >= KERNEL_VERSION(2, 6, 36)) || defined(COMPAT_KERNEL_RELEASE)
 	enum nl80211_tx_power_setting type, int mbm)
 #else
@@ -3724,6 +3731,9 @@ if(type == NL80211_TX_POWER_FIXED) {
 static int cfg80211_rtw_get_txpower(struct wiphy *wiphy,
 #if (CFG80211_API_LEVEL >= KERNEL_VERSION(3, 8, 0))
 	struct wireless_dev *wdev,
+#endif
+#if (CFG80211_API_LEVEL >= KERNEL_VERSION(6, 17, 0))
+  int radio_idx,
 #endif
 #if (CFG80211_API_LEVEL >= KERNEL_VERSION(6, 14, 0))
   unsigned int link_id,


### PR DESCRIPTION
- Rename `del_timer_sync` to `timer_delete_sync` - kernel 6.15.
- Rename `from_timer` to `timer_container_of` - kernel 6.16.
- Add missing `radio_idx` parameter for `cfg80211_ops.set_tx_power`, `cfg80211_ops.get_tx_power`, `cfg80211_ops.set_wiphy_params`  - kernel 6.17.
- Use `asflags-y ccflags-y cppflags-y ldflags-y` instead of deprecated `EXTRA_AFLAGS EXTRA_CFLAGS EXTRA_CPPFLAGS EXTRA_LDFLAGS`.
- Suppress compilation warnings.
- Tested with kernel 6.17.4-200.fc42.x86_64