### PR TITLE
Fix build on Raspberry Pi with kernel 6.18 headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1606,7 +1606,7 @@ export CONFIG_RTL8812AU = m
 all: modules
 
 modules:
-	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd) O="$(KBUILD_OUTPUT)" modules
+	$(MAKE) ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd) modules
 
 strip:
 	$(CROSS_COMPILE)strip $(MODULE_NAME).ko --strip-unneeded

--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -16,6 +16,7 @@
 
 #ifdef __KERNEL__
 	#include <linux/if_arp.h>
+	#include <linux/version.h>
 	#include <net/ip.h>
 	#include <linux/atalk.h>
 	#include <linux/udp.h>


### PR DESCRIPTION
   Fix two issues that prevent building on Raspberry Pi with kernel 6.18 headers:

   1. The modules target passes O="" (empty KBUILD_OUTPUT) to the kernel
      Makefile. On Raspberry Pi kernel headers, an empty O= overrides the
      KBUILD_OUTPUT preset in the headers Makefile, causing objtree to
      resolve to the common headers directory and the build to fail with
      "include/config/auto.conf: No such file or directory" and
      "asm/types.h: No such file or directory".

   2. core/rtw_br_ext.c uses LINUX_VERSION_CODE/KERNEL_VERSION without
      including linux/version.h, which fails to compile with the kernel
      7.1 pppoe struct fix (#53).

   Both changes were verified on a Raspberry Pi CM4 (kernel 6.18.34+rpt-rpi-v8).